### PR TITLE
Small fix so user input is picked up

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -104,7 +104,7 @@ const WatsonConversationWare = (options) => {
 
     return sendMessageToWatson({
       context,
-      userText,
+      text: userText,
       watson,
       workspaceId: options.workspaceId,
     })


### PR DESCRIPTION
Hello, just saw this small problem. 
The `sendMessageToWatson` function is expecting `params.text` not `params.userText` which is what it is currently getting.  
Causing some problems reading input.